### PR TITLE
Fix timestamp offset of segment events

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # GstInterpipe 1.0
-stInterpipe is a Gstreamer plug-in that allows communication between
+GstInterpipe is a Gstreamer plug-in that allows communication between
 two independent pipelines. The plug-in consists of two elements:
 - interpipesink
 - interpipesrc

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # GstInterpipe 1.0
-GstInterpipe is a Gstreamer plug-in that allows communication between
+stInterpipe is a Gstreamer plug-in that allows communication between
 two independent pipelines. The plug-in consists of two elements:
 - interpipesink
 - interpipesrc

--- a/gst/interpipe/gstinterpipesrc.c
+++ b/gst/interpipe/gstinterpipesrc.c
@@ -444,7 +444,7 @@ gst_inter_pipe_src_event (GstBaseSrc * base, GstEvent * event)
   src = GST_INTER_PIPE_SRC (base);
   node = gst_inter_pipe_get_node (src->listen_to);
 
-  if (GST_EVENT_IS_UPSTREAM (event) && GST_EVENT_TYPE (event) != GST_EVENT_QOS) {       // skip forwarding of QOS events
+  if (GST_EVENT_IS_UPSTREAM (event) && GST_EVENT_TYPE (event) != GST_EVENT_QOS && GST_EVENT_TYPE (event) != GST_EVENT_LATENCY) {        // skip forwarding of certain events
 
     GST_INFO_OBJECT (src, "Incoming upstream event %s",
         GST_EVENT_TYPE_NAME (event));
@@ -484,7 +484,7 @@ gst_inter_pipe_src_create (GstBaseSrc * base, guint64 offset, guint size,
       "Dequeue buffer %p with timestamp (PTS) %" GST_TIME_FORMAT, *buf,
       GST_TIME_ARGS (GST_BUFFER_PTS (*buf)));
 
-  if (!g_queue_is_empty (src->pending_serial_events)) {
+  while (!g_queue_is_empty (src->pending_serial_events)) {
     guint curr_bytes;
     /*Pending Serial Events Queue */
     serial_event = g_queue_peek_head (src->pending_serial_events);
@@ -506,6 +506,7 @@ gst_inter_pipe_src_create (GstBaseSrc * base, guint64 offset, guint size,
       GST_DEBUG_OBJECT (src, "Event %s timestamp is greater than the "
           "buffer timestamp, can't send serial event yet",
           GST_EVENT_TYPE_NAME (serial_event));
+      break;
     }
   }
 
@@ -634,7 +635,8 @@ gst_inter_pipe_src_push_buffer (GstInterPipeIListener * iface,
   src = GST_INTER_PIPE_SRC (iface);
   appsrc = GST_APP_SRC (src);
 
-  GST_LOG_OBJECT (src, "Incoming buffer: %p", buffer);
+  GST_LOG_OBJECT (src, "Incoming buffer: %" GST_TIME_FORMAT,
+      GST_TIME_ARGS (GST_BUFFER_PTS (buffer)));
 
   if (GST_STATE (GST_ELEMENT (appsrc)) < GST_STATE_PAUSED) {
     gst_buffer_unref (buffer);
@@ -682,6 +684,7 @@ gst_inter_pipe_src_push_buffer (GstInterPipeIListener * iface,
         GST_TIME_ARGS (GST_BUFFER_PTS (buffer)));
   } else if (GST_INTER_PIPE_SRC_RESTART_TIMESTAMP == src->stream_sync) {
     /* Remove the incoming timestamp to be generated according this basetime */
+    buffer = gst_buffer_make_writable (buffer);
     GST_BUFFER_PTS (buffer) = GST_CLOCK_TIME_NONE;
     GST_BUFFER_DTS (buffer) = GST_CLOCK_TIME_NONE;
   }
@@ -708,7 +711,6 @@ gst_inter_pipe_src_push_event (GstInterPipeIListener * iface, GstEvent * event,
   GstInterPipeSrc *src;
   GstAppSrc *appsrc;
   GstPad *srcpad;
-  guint64 srcbasetime;
   gboolean ret = TRUE;
 
   src = GST_INTER_PIPE_SRC (iface);
@@ -725,11 +727,11 @@ gst_inter_pipe_src_push_event (GstInterPipeIListener * iface, GstEvent * event,
 
     ret = gst_pad_push_event (srcpad, event);
   } else {
-
-    srcbasetime = gst_element_get_base_time (GST_ELEMENT (appsrc));
-
     if (GST_EVENT_TYPE (event) == GST_EVENT_SEGMENT) {
       GstSegment segment;
+      guint64 srcbasetime;
+
+      srcbasetime = gst_element_get_base_time (GST_ELEMENT (appsrc));
 
       /* copy segment values */
       gst_event_copy_segment (event, &segment);

--- a/gst/interpipe/gstinterpipesrc.c
+++ b/gst/interpipe/gstinterpipesrc.c
@@ -444,7 +444,7 @@ gst_inter_pipe_src_event (GstBaseSrc * base, GstEvent * event)
   src = GST_INTER_PIPE_SRC (base);
   node = gst_inter_pipe_get_node (src->listen_to);
 
-  if (GST_EVENT_IS_UPSTREAM (event)) {
+  if (GST_EVENT_IS_UPSTREAM (event) && GST_EVENT_TYPE (event) != GST_EVENT_QOS) {       // skip forwarding of QOS events
 
     GST_INFO_OBJECT (src, "Incoming upstream event %s",
         GST_EVENT_TYPE_NAME (event));
@@ -726,21 +726,19 @@ gst_inter_pipe_src_push_event (GstInterPipeIListener * iface, GstEvent * event,
     ret = gst_pad_push_event (srcpad, event);
   } else {
 
-    event = gst_event_make_writable (event);
     srcbasetime = gst_element_get_base_time (GST_ELEMENT (appsrc));
 
-    if (srcbasetime > basetime) {
-      GST_EVENT_TIMESTAMP (event) =
-          GST_EVENT_TIMESTAMP (event) - (srcbasetime - basetime);
-    } else {
-      GST_EVENT_TIMESTAMP (event) =
-          GST_EVENT_TIMESTAMP (event) + (basetime - srcbasetime);
-    }
+    if (GST_EVENT_TYPE (event) == GST_EVENT_SEGMENT) {
+      GstSegment segment;
 
-    GST_DEBUG_OBJECT (src,
-        "Event %s with calculated timestamp %" GST_TIME_FORMAT
-        " enqueued on serial pending events", GST_EVENT_TYPE_NAME (event),
-        GST_TIME_ARGS (GST_EVENT_TIMESTAMP (event)));
+      /* copy segment values */
+      gst_event_copy_segment (event, &segment);
+      gst_event_unref (event);
+
+      gst_segment_offset_running_time (&segment, segment.format,
+          srcbasetime - basetime);
+      event = gst_event_new_segment (&segment);
+    }
 
     g_queue_push_tail (src->pending_serial_events, event);
   }


### PR DESCRIPTION
Also ignore upstream QoS events (we don't want them to be passed through to the `interpipesink`).