### PR TITLE
Do not inform node that listener has been removed

### DIFF
--- a/gst/interpipe/gstinterpipe.c
+++ b/gst/interpipe/gstinterpipe.c
@@ -343,6 +343,7 @@ gst_inter_pipe_notify_node_removed (gpointer _listener_name, gpointer _listener,
   GST_INFO ("Notifying node removed: %s", node_name);
 
   gst_inter_pipe_ilistener_node_removed (listener, node_name);
+  listener_priv->listen_to = NULL;
 }
 
 gboolean

--- a/gst/interpipe/gstinterpipesrc.c
+++ b/gst/interpipe/gstinterpipesrc.c
@@ -559,9 +559,9 @@ gst_inter_pipe_src_node_removed (GstInterPipeIListener * iface,
   src = GST_INTER_PIPE_SRC (iface);
 
   GST_INFO_OBJECT (src, "Node %s removed. Leaving.", node_name);
-  if (g_strcmp0 (src->listen_to, node_name) == 0) {
-    gst_inter_pipe_leave_node (iface);
-  }
+
+  // NOTE(mgi): previously this called 'gst_inter_pipe_leave_node'
+  // I don't believe this is the correct behaviour, as the node in question (the sink) has been removed
 
   return TRUE;
 }


### PR DESCRIPTION
We would get the following warning when an `interpipesink` node was destroyed while `interpipesrc` listeners were still connected:
```
0:00:06.424572954 12676      0x2b8c150 DEBUG          interpipesink gstinterpipesink.c:306:gst_inter_pipe_sink_finalize:<node_feed1_audio> Removing node node_feed1_audio and associated listeners
0:00:06.424598031 12676      0x2b8c150 WARN               interpipe gstinterpipe.c:236:gst_inter_pipe_leave_node_priv: Node node_feed1_audio not found. Could not leave node.
```
There is a chain of function calls to sift through, but what happens is this:
1. `gstinterpipe.c`: `gst_inter_pipe_remove_node` removes the `interpipesink` node in question
2. `gstinterpipe.c`: `gst_inter_pipe_remove_node` calls `gst_inter_pipe_notify_node_removed` for each listener
3. `gstinterpipe.c`: `gst_inter_pipe_notify_node_removed` calls `gst_inter_pipe_ilistener_node_removed` (an interface implemented by `interpipesrc`)
4. `gstinterpipesrc.c`: `gst_inter_pipe_src_node_removed` calls `gst_inter_pipe_leave_node`
5. `gstinterpipe.c`: `gst_inter_pipe_leave_node` calls `gst_inter_pipe_leave_node_priv` (note: this also gets called when the listener disconnects from an active `interpipesink`, which is a different scenario to the `interpipesink` disappearing)
6. `gstinterpipe.c`: `gst_inter_pipe_leave_node_priv` tries to remove the listener from the `interpipesink` node, but it no longer exists (see step 1)
7. `gstinterpipe.c`: `gst_inter_pipe_leave_node_priv` returns a warning stating that the node doesn't exist, and sets `GstInterPipeListenerPriv->listen_to = NULL` (`GstInterPipeListenerPriv` is a struct which stores the listener and the name of the node it's listening to; these are stored in a hash table)

The change is to _not_ call `gst_inter_pipe_leave_node` (step 4 onwards) when the listener is being notified of a node removal. We know that we've already removed the node (see step 1), so we only need to set the `listen_to` field (of `GstInterPipeListenerPriv`) to `NULL` (added in `gstinterpipe.c`, in `gst_inter_pipe_notify_node_removed`).