### PR TITLE
Only notify listeners listening to the removed node

### DIFF
--- a/gst/interpipe/gstinterpipe.c
+++ b/gst/interpipe/gstinterpipe.c
@@ -340,10 +340,11 @@ gst_inter_pipe_notify_node_removed (gpointer _listener_name, gpointer _listener,
   GstInterPipeListenerPriv *listener_priv = _listener;
   GstInterPipeIListener *listener = listener_priv->listener;
 
-  GST_INFO ("Notifying node removed: %s", node_name);
-
-  gst_inter_pipe_ilistener_node_removed (listener, node_name);
-  listener_priv->listen_to = NULL;
+  if (g_strcmp0 (listener_priv->listen_to, node_name) == 0) {
+    GST_INFO ("Notifying node removed: %s", node_name);
+    gst_inter_pipe_ilistener_node_removed (listener, node_name);
+    listener_priv->listen_to = NULL;
+  }
 }
 
 gboolean


### PR DESCRIPTION
Previously all nodes were notified, which resulted in all nodes nulling out their `listen-to` property. This bug was introduced in #2.