### PR TITLE
interpipesink: Only send segment event if we have seen one

### DIFF
--- a/gst/interpipe/gstinterpipesink.c
+++ b/gst/interpipe/gstinterpipesink.c
@@ -820,9 +820,12 @@ add_to_list:
     goto already_registered;
 
   /* send segment event to new listener */
-  data_array[0] = sink;
-  data_array[1] = sink->segment_event;
-  gst_inter_pipe_sink_forward_event (NULL, listener, data_array);
+  if (sink->segment_event) {
+    data_array[0] = sink;
+    data_array[1] = sink->segment_event;
+    GST_INFO_OBJECT (sink, "Forwarding segment event to new listener");
+    gst_inter_pipe_sink_forward_event (NULL, listener, data_array);
+  }
 
   g_hash_table_insert (listeners, (gpointer) listener_name,
       (gpointer) listener);


### PR DESCRIPTION
If the `interpipesink` hasn't received a segment event on its source pad when an `interpipesrc` connects then it will try to send a `NULL` value which causes a segfault.